### PR TITLE
R_ Calloc and Free

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PeakSegJoint
 Maintainer: Toby Dylan Hocking <toby.hocking@r-project.org>
 Author: Toby Dylan Hocking
-Version: 2024.6.27
+Version: 2024.10.1
 License: GPL-3
 URL: https://github.com/tdhock/PeakSegJoint
 BugReports: https://github.com/tdhock/PeakSegJoint/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,10 @@
 Package: PeakSegJoint
 Maintainer: Toby Dylan Hocking <toby.hocking@r-project.org>
-Author: Toby Dylan Hocking
+Authors@R: person(
+ given = c("Toby", "Dylan"),
+ family = "Hocking",
+ role = c("aut", "cre"),
+ email = "toby.hocking@r-project.org")
 Version: 2024.10.1
 License: GPL-3
 URL: https://github.com/tdhock/PeakSegJoint

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,4 @@
 Package: PeakSegJoint
-Maintainer: Toby Dylan Hocking <toby.hocking@r-project.org>
 Authors@R: person(
  given = c("Toby", "Dylan"),
  family = "Hocking",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Changes in version 2024.10.1
+
+- update src/*.c to use R_ versions of Calloc and Free, so that compilation works with _R_USE_STRICT_R_HEADERS_=true, thanks CRAN.
+
 Changes in version 2024.6.27
 
 - update PeakSegJoint.c to avoid integer overflow, thanks CRAN.

--- a/man/ConvertModelList.Rd
+++ b/man/ConvertModelList.Rd
@@ -16,7 +16,7 @@ as segments, but with only the second/peak segments; loss has one
 row for each model size; modelSelection has one row for each model
 size that can be selected, see exactModelSelection.}
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/man/PeakErrorSamples.Rd
+++ b/man/PeakErrorSamples.Rd
@@ -11,7 +11,7 @@
 
 \value{data.frame of error \code{regions} with sample.id.}
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/man/PeakSegJointError.Rd
+++ b/man/PeakSegJointError.Rd
@@ -17,7 +17,7 @@ exactModelSelection), target (numeric vector of length 2, lower
 and upper limits of target interval of log.lambda penalty values
 in the interval regression problem).}
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/man/PeakSegJointFaster.Rd
+++ b/man/PeakSegJointFaster.Rd
@@ -19,7 +19,7 @@ chromEnd, count.}
 
 \value{List of model fit results.}
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/man/PeakSegJointFasterOne.Rd
+++ b/man/PeakSegJointFasterOne.Rd
@@ -17,7 +17,7 @@ single data.frame with additional column sample.id.}
 
 \value{List of model fit results, see examples to see how to use it.}
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/man/PeakSegJointHeuristic.Rd
+++ b/man/PeakSegJointHeuristic.Rd
@@ -24,7 +24,7 @@ single data.frame with additional column sample.id.}
 \value{List of model fit results, which can be passed to \code{\link{ConvertModelList}}
 for easier interpretation.}
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/man/PeakSegJointHeuristicStep1.Rd
+++ b/man/PeakSegJointHeuristicStep1.Rd
@@ -18,7 +18,7 @@ single data.frame with additional column sample.id.}
 \value{List of model fit results, which can be passed to \code{\link{ConvertModelList}}
 for easier interpretation.}
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/man/PeakSegJointHeuristicStep2.Rd
+++ b/man/PeakSegJointHeuristicStep2.Rd
@@ -19,7 +19,7 @@ single data.frame with additional column sample.id.}
 \value{List of model fit results, which can be passed to \code{\link{ConvertModelList}}
 for easier interpretation.}
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/man/PeakSegJointSeveral.Rd
+++ b/man/PeakSegJointSeveral.Rd
@@ -28,7 +28,7 @@ closer to the global optimum.}
 \value{List of model fit results, which can be passed to \code{\link{ConvertModelList}}
 for easier interpretation.}
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/man/PoissonLoss.Rd
+++ b/man/PoissonLoss.Rd
@@ -16,7 +16,7 @@ maximum likelihood segment with mean zero must be zero.}
 
 
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/man/ProfileList.Rd
+++ b/man/ProfileList.Rd
@@ -12,7 +12,7 @@ single data.frame with additional column sample.id.}
 \value{Named list of data.frames with columns chromStart, chromEnd,
 count.}
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/man/binSum.Rd
+++ b/man/binSum.Rd
@@ -19,7 +19,7 @@ bins (returning a data.frame with fewer than \code{n.bins} rows).}
 \value{data.frame with \code{n.bins} rows and columns chromStart, chromEnd,
 count, mean.}
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/man/clusterPeaks.Rd
+++ b/man/clusterPeaks.Rd
@@ -10,7 +10,7 @@
 \value{\code{peaks} data.frame, sorted by chromStart, with an additional column
 cluster.}
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/man/featureMatrixJoint.Rd
+++ b/man/featureMatrixJoint.Rd
@@ -9,7 +9,7 @@
 
 \value{Numeric feature matrix (samples x features).}
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/man/multiClusterPeaks.Rd
+++ b/man/multiClusterPeaks.Rd
@@ -10,7 +10,7 @@
 \value{\code{peaks} data.frame, sorted by chromStart, with an additional column
 cluster.}
 
-\author{Toby Dylan Hocking}
+\author{Toby Dylan Hocking <toby.hocking@r-project.org> [aut, cre]}
 
 
 

--- a/src/PeakSegJoint.c
+++ b/src/PeakSegJoint.c
@@ -85,7 +85,7 @@ int PeakSegJointHeuristicStep1(
   //printf("bin_start_end=[%d,%d]\n", seg1_chromStart, seg3_chromEnd);
   // sample_*_mat variables are matrices n_bins x n_samples (in
   // contrast to model_*_mat which are n_bins x n_segments=3).
-  double *sample_count_mat = Calloc(n_bins * n_samples, double);
+  double *sample_count_mat = R_Calloc(n_bins * n_samples, double);
   double *count_vec, *cumsum_vec, cumsum_value;
   int status;
   for(int sample_i=0; sample_i < n_samples; sample_i++){
@@ -102,7 +102,7 @@ int PeakSegJointHeuristicStep1(
     /* } */
     /* printf("\n"); */
     if(status != 0){
-      Free(sample_count_mat);
+      R_Free(sample_count_mat);
       return status;
     }
     /* Profiles may not have the same first chromStart and last
@@ -121,7 +121,7 @@ int PeakSegJointHeuristicStep1(
 		    seg1_chromStart,
 		    EMPTY_AS_ZERO);
     if(status != 0){
-      Free(sample_count_mat);
+      R_Free(sample_count_mat);
       return status;
     }
     count_vec[0] -= extra_count;
@@ -133,7 +133,7 @@ int PeakSegJointHeuristicStep1(
 		    unfilled_chromEnd,
 		    EMPTY_AS_ZERO);
     if(status != 0){
-      Free(sample_count_mat);
+      R_Free(sample_count_mat);
       return status;
     }
     count_vec[n_bins - 1] -= extra_count;
@@ -142,8 +142,8 @@ int PeakSegJointHeuristicStep1(
   int bin_i, offset;
   double mean_value, loss_value;
   double flat_loss_total = 0.0;
-  double *sample_cumsum_mat = Calloc(n_bins * n_samples, double);
-  struct LossIndex *diff_index_vec = Calloc(n_samples,struct LossIndex);
+  double *sample_cumsum_mat = R_Calloc(n_bins * n_samples, double);
+  struct LossIndex *diff_index_vec = R_Calloc(n_samples,struct LossIndex);
   int n_feasible;
   for(int sample_i=0; sample_i < n_samples; sample_i++){
     cumsum_value = 0;
@@ -173,8 +173,8 @@ int PeakSegJointHeuristicStep1(
   double *seg1_mean_vec = model_list->mean_mat;
   double *seg2_mean_vec = model_list->mean_mat + n_samples;
   double *seg3_mean_vec = model_list->mean_mat + n_samples*2;
-  double *peak_loss_vec = Calloc(n_samples,double);
-  double *seg1_loss_vec = Calloc(n_samples,double);
+  double *peak_loss_vec = R_Calloc(n_samples,double);
+  double *seg1_loss_vec = R_Calloc(n_samples,double);
   /*
     The for loops below implement the GridSearch() function mentioned
     on line 2 of the JointZoom algorithm in the PeakSegJoint paper.
@@ -285,11 +285,11 @@ int PeakSegJointHeuristicStep1(
       }//if(n_feasible)
     }//seg2_LastIndex
   }//seg2_FirstIndex
-  Free(sample_cumsum_mat);
-  Free(sample_count_mat);
-  Free(peak_loss_vec);
-  Free(seg1_loss_vec);
-  Free(diff_index_vec);
+  R_Free(sample_cumsum_mat);
+  R_Free(sample_count_mat);
+  R_Free(peak_loss_vec);
+  R_Free(seg1_loss_vec);
+  R_Free(diff_index_vec);
   return status;
 }
 
@@ -304,14 +304,14 @@ PeakSegJointHeuristicStep2
   struct Profile *profile;
   int bases_per_bin;
   int left_chromStart, right_chromStart;
-  double *left_bin_vec = Calloc(n_bins, double);
-  double *right_bin_vec = Calloc(n_bins, double);
-  double *left_cumsum_mat = Calloc(n_bins * n_samples, double);
-  double *right_cumsum_mat = Calloc(n_bins * n_samples, double);
+  double *left_bin_vec = R_Calloc(n_bins, double);
+  double *right_bin_vec = R_Calloc(n_bins, double);
+  double *left_cumsum_mat = R_Calloc(n_bins * n_samples, double);
+  double *right_cumsum_mat = R_Calloc(n_bins * n_samples, double);
   double *seg1_mean_vec = model_list->mean_mat;
   double *seg2_mean_vec = model_list->mean_mat + n_samples;
   double *seg3_mean_vec = model_list->mean_mat + n_samples*2;
-  double *seg1_loss_vec = Calloc(n_samples,double);
+  double *seg1_loss_vec = R_Calloc(n_samples,double);
   double total_loss, loss_value, mean_value;
   double bin_bases, data_bases;
   int extra_before = model_list->data_start_end[0] - 
@@ -361,11 +361,11 @@ PeakSegJointHeuristicStep2
 			    bases_per_bin, n_bins);
 	  if(status != 0){
 	    //printf("binSumLR bad status\n");
-	    Free(left_bin_vec);
-	    Free(right_bin_vec);
-	    Free(left_cumsum_mat);
-	    Free(right_cumsum_mat);
-	    Free(seg1_loss_vec);
+	    R_Free(left_bin_vec);
+	    R_Free(right_bin_vec);
+	    R_Free(left_cumsum_mat);
+	    R_Free(right_cumsum_mat);
+	    R_Free(seg1_loss_vec);
 	    return status;
 	  }
 	  left_cumsum_vec = left_cumsum_mat + n_bins*sample_i;
@@ -531,12 +531,12 @@ PeakSegJointHeuristicStep2
       }//while(1 < bases_per_bin)
     }//if(loss < INFINITY
   }//for(n_peaks
-  //printf("Free at end\n");
-  Free(left_bin_vec);
-  Free(right_bin_vec);
-  Free(left_cumsum_mat);
-  Free(right_cumsum_mat);
-  Free(seg1_loss_vec);
+  //printf("R_Free at end\n");
+  R_Free(left_bin_vec);
+  R_Free(right_bin_vec);
+  R_Free(left_cumsum_mat);
+  R_Free(right_cumsum_mat);
+  R_Free(seg1_loss_vec);
   return 0;
 }
 
@@ -550,7 +550,7 @@ int PeakSegJointHeuristicStep3
   double *seg1_mean_vec = model_list->mean_mat;
   double *seg2_mean_vec = model_list->mean_mat + n_samples;
   double *seg3_mean_vec = model_list->mean_mat + n_samples*2;
-  struct LossIndex *diff_index_vec = Calloc(n_samples,struct LossIndex);
+  struct LossIndex *diff_index_vec = R_Calloc(n_samples,struct LossIndex);
   int n_feasible, peakStart, peakEnd, status;
   double total;
   int dataStart = model_list->data_start_end[0];
@@ -571,7 +571,7 @@ int PeakSegJointHeuristicStep3
 			profile->coverage, profile->n_entries,
 			&total, dataStart, peakStart);
 	if(status != 0){
-	  Free(diff_index_vec);
+	  R_Free(diff_index_vec);
 	  return status;
 	}
 	data_bases = peakStart - dataStart;
@@ -583,7 +583,7 @@ int PeakSegJointHeuristicStep3
 			profile->coverage, profile->n_entries,
 			&total, peakStart, peakEnd);
 	if(status != 0){
-	  Free(diff_index_vec);
+	  R_Free(diff_index_vec);
 	  return status;
 	}
 	data_bases = peakEnd - peakStart;
@@ -595,7 +595,7 @@ int PeakSegJointHeuristicStep3
 			profile->coverage, profile->n_entries,
 			&total, peakEnd, dataEnd);
 	if(status != 0){
-	  Free(diff_index_vec);
+	  R_Free(diff_index_vec);
 	  return status;
 	}
 	data_bases = dataEnd - peakEnd;
@@ -650,6 +650,6 @@ int PeakSegJointHeuristicStep3
       }//if(n_feasible)
     }//if(prev_model->loss[0] < INFINITY
   }//for(n_peaks
-  Free(diff_index_vec);
+  R_Free(diff_index_vec);
   return 0;
 }

--- a/src/PeakSegJointFaster.c
+++ b/src/PeakSegJointFaster.c
@@ -78,23 +78,23 @@ int PeakSegJointFaster(
   int seg1_chromStart = unfilled_chromStart - extra_before;
   int seg3_chromEnd = unfilled_chromEnd + extra_after;
 
-  double *sample_count_mat = Calloc(n_bins * n_samples,double);
-  double *last_cumsum_vec = Calloc(n_samples,double);
-  double *sample_cumsum_mat = Calloc(n_bins * n_samples,double);
+  double *sample_count_mat = R_Calloc(n_bins * n_samples,double);
+  double *last_cumsum_vec = R_Calloc(n_samples,double);
+  double *sample_cumsum_mat = R_Calloc(n_bins * n_samples,double);
 
-  double *seg1_mean_vec = Calloc(n_samples,double);
-  double *seg2_mean_vec = Calloc(n_samples,double);
-  double *seg3_mean_vec = Calloc(n_samples,double);
+  double *seg1_mean_vec = R_Calloc(n_samples,double);
+  double *seg2_mean_vec = R_Calloc(n_samples,double);
+  double *seg3_mean_vec = R_Calloc(n_samples,double);
   
-  double *seg1_loss_vec = Calloc(n_samples,double);
-  double *candidate_loss_vec = Calloc(n_samples,double);
+  double *seg1_loss_vec = R_Calloc(n_samples,double);
+  double *candidate_loss_vec = R_Calloc(n_samples,double);
 
-  double *left_bin_vec = Calloc(n_bins,double);
-  double *right_bin_vec = Calloc(n_bins,double);
-  double *left_cumsum_mat = Calloc(n_bins * n_samples,double);
-  double *right_cumsum_mat = Calloc(n_bins * n_samples,double);
-  double *left_initial_cumsum_vec = Calloc(n_samples,double);
-  double *right_initial_cumsum_vec = Calloc(n_samples,double);
+  double *left_bin_vec = R_Calloc(n_bins,double);
+  double *right_bin_vec = R_Calloc(n_bins,double);
+  double *left_cumsum_mat = R_Calloc(n_bins * n_samples,double);
+  double *right_cumsum_mat = R_Calloc(n_bins * n_samples,double);
+  double *left_initial_cumsum_vec = R_Calloc(n_samples,double);
+  double *right_initial_cumsum_vec = R_Calloc(n_samples,double);
   
   double *left_cumsum_vec, *right_cumsum_vec;
   double left_cumsum_value, right_cumsum_value;
@@ -112,23 +112,23 @@ int PeakSegJointFaster(
 		    bases_per_bin, n_bins, seg1_chromStart, 
 		    EMPTY_AS_ZERO);
     if(status != 0){
-      Free(sample_count_mat);
-      Free(last_cumsum_vec);
-      Free(sample_cumsum_mat);
+      R_Free(sample_count_mat);
+      R_Free(last_cumsum_vec);
+      R_Free(sample_cumsum_mat);
   
-      Free(seg1_mean_vec);
-      Free(seg2_mean_vec);
-      Free(seg3_mean_vec);
+      R_Free(seg1_mean_vec);
+      R_Free(seg2_mean_vec);
+      R_Free(seg3_mean_vec);
 
-      Free(seg1_loss_vec);
-      Free(candidate_loss_vec);
+      R_Free(seg1_loss_vec);
+      R_Free(candidate_loss_vec);
 
-      Free(left_bin_vec);
-      Free(right_bin_vec);
-      Free(left_cumsum_mat);
-      Free(right_cumsum_mat);
-      Free(left_initial_cumsum_vec);
-      Free(right_initial_cumsum_vec);
+      R_Free(left_bin_vec);
+      R_Free(right_bin_vec);
+      R_Free(left_cumsum_mat);
+      R_Free(right_cumsum_mat);
+      R_Free(left_initial_cumsum_vec);
+      R_Free(right_initial_cumsum_vec);
       return status;
     }
   }//for sample_i
@@ -254,23 +254,23 @@ int PeakSegJointFaster(
 			bases_per_bin, n_bins);
       if(status != 0){
 	//printf("binSumLR bad status\n");
-	Free(sample_count_mat);
-	Free(last_cumsum_vec);
-	Free(sample_cumsum_mat);
+	R_Free(sample_count_mat);
+	R_Free(last_cumsum_vec);
+	R_Free(sample_cumsum_mat);
   
-	Free(seg1_mean_vec);
-	Free(seg2_mean_vec);
-	Free(seg3_mean_vec);
+	R_Free(seg1_mean_vec);
+	R_Free(seg2_mean_vec);
+	R_Free(seg3_mean_vec);
 
-	Free(seg1_loss_vec);
-	Free(candidate_loss_vec);
+	R_Free(seg1_loss_vec);
+	R_Free(candidate_loss_vec);
 
-	Free(left_bin_vec);
-	Free(right_bin_vec);
-	Free(left_cumsum_mat);
-	Free(right_cumsum_mat);
-	Free(left_initial_cumsum_vec);
-	Free(right_initial_cumsum_vec);
+	R_Free(left_bin_vec);
+	R_Free(right_bin_vec);
+	R_Free(left_cumsum_mat);
+	R_Free(right_cumsum_mat);
+	R_Free(left_initial_cumsum_vec);
+	R_Free(right_initial_cumsum_vec);
 	return status;
       }
       left_cumsum_vec = left_cumsum_mat + n_bins*sample_i;
@@ -383,24 +383,24 @@ int PeakSegJointFaster(
       }
     }
   }//while(1 < bases_per_bin)
-  //printf("Free at end\n");
-  Free(sample_count_mat);
-  Free(last_cumsum_vec);
-  Free(sample_cumsum_mat);
+  //printf("R_Free at end\n");
+  R_Free(sample_count_mat);
+  R_Free(last_cumsum_vec);
+  R_Free(sample_cumsum_mat);
   
-  Free(seg1_mean_vec);
-  Free(seg2_mean_vec);
-  Free(seg3_mean_vec);
+  R_Free(seg1_mean_vec);
+  R_Free(seg2_mean_vec);
+  R_Free(seg3_mean_vec);
 
-  Free(seg1_loss_vec);
-  Free(candidate_loss_vec);
+  R_Free(seg1_loss_vec);
+  R_Free(candidate_loss_vec);
 
-  Free(left_bin_vec);
-  Free(right_bin_vec);
-  Free(left_cumsum_mat);
-  Free(right_cumsum_mat);
-  Free(left_initial_cumsum_vec);
-  Free(right_initial_cumsum_vec);
+  R_Free(left_bin_vec);
+  R_Free(right_bin_vec);
+  R_Free(left_cumsum_mat);
+  R_Free(right_cumsum_mat);
+  R_Free(left_initial_cumsum_vec);
+  R_Free(right_initial_cumsum_vec);
   
   return 0;
 }

--- a/src/PeakSegJoint_interface.c
+++ b/src/PeakSegJoint_interface.c
@@ -90,7 +90,7 @@ Ralloc_profile_list
   int profile_i;
   SEXP df, chromStart, chromEnd, coverage;
   profile_list->n_profiles = length(profile_list_sexp);
-  profile_list->profile_vec = Calloc(profile_list->n_profiles,struct Profile);
+  profile_list->profile_vec = R_Calloc(profile_list->n_profiles,struct Profile);
   for(profile_i=0; profile_i < profile_list->n_profiles; profile_i++){
     df = VECTOR_ELT(profile_list_sexp, profile_i);
     profile = profile_list->profile_vec + profile_i;
@@ -249,9 +249,9 @@ Ralloc_model_struct
 struct PeakSegJointModelList *
 malloc_PeakSegJointModelList(int n_models){
   struct PeakSegJointModelList *model_list = 
-    Calloc(1,struct PeakSegJointModelList);
+    R_Calloc(1,struct PeakSegJointModelList);
   model_list->n_models = n_models;
-  model_list->model_vec = Calloc(n_models,struct PeakSegJointModel);
+  model_list->model_vec = R_Calloc(n_models,struct PeakSegJointModel);
   return model_list;
 }
 

--- a/src/binSum.c
+++ b/src/binSum.c
@@ -163,7 +163,7 @@ int binSum
   }
   /* printf("bin_chromStart=%d bin_size=%d n_bins=%d status=%d\n", */
   /* 	 bin_chromStart, bin_size, n_bins, status_for_empty_bin); */
-  int *bin_touched = Calloc(n_bins,int);
+  int *bin_touched = R_Calloc(n_bins,int);
   for(bin_i = 0; bin_i < n_bins; bin_i++){
     bin_total[bin_i] = 0;
     bin_touched[bin_i] = 0;
@@ -241,7 +241,7 @@ int binSum
 
   // If EMPTY_AS_ZERO flag, return now (untouched totals are zero).
   if(status_for_empty_bin == EMPTY_AS_ZERO){
-    Free(bin_touched);
+    R_Free(bin_touched);
     return 0;
   }
   // If there was no data at all that overlapped a bin (not even
@@ -253,6 +253,6 @@ int binSum
       status = status_for_empty_bin;
     }
   }
-  Free(bin_touched);
+  R_Free(bin_touched);
   return status;
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,5 @@
-library(testthat)
-suite <- Sys.getenv("TEST_SUITE")
-if(suite=="")suite <- NULL
-test_check("PeakSegJoint", filter=suite)
+if(require(testthat)){
+  suite <- Sys.getenv("TEST_SUITE")
+  if(suite=="")suite <- NULL
+  test_check("PeakSegJoint", filter=suite)
+}


### PR DESCRIPTION
this fixes
```
* installing *source* package ‘PeakSegJoint’ ...
** package ‘PeakSegJoint’ successfully unpacked and MD5 sums checked
** using staged installation
** libs
using C compiler: ‘gcc-14 (GCC) 14.2.0’
make[1]: Entering directory '/data/gannet/ripley/R/packages/tests-Strict/PeakSegJoint/src'
gcc-14 -I"/data/gannet/ripley/R/R-devel/include" -DNDEBUG   -I/usr/local/include  -DSTRICT_R_HEADERS=1  -fpic  -g -O2 -Wall -pedantic -mtune=native -Wp,-D_FORTIFY_SOURCE=3 -fexceptions -fstack-protector-strong -fstack-clash-protection -fcf-protection -Werror=implicit-function-declaration -Wstrict-prototypes  -c OptimalPoissonLoss.c -o OptimalPoissonLoss.o
gcc-14 -I"/data/gannet/ripley/R/R-devel/include" -DNDEBUG   -I/usr/local/include  -DSTRICT_R_HEADERS=1  -fpic  -g -O2 -Wall -pedantic -mtune=native -Wp,-D_FORTIFY_SOURCE=3 -fexceptions -fstack-protector-strong -fstack-clash-protection -fcf-protection -Werror=implicit-function-declaration -Wstrict-prototypes  -c PeakSegJoint.c -o PeakSegJoint.o
PeakSegJoint.c: In function 'PeakSegJointHeuristicStep1':
PeakSegJoint.c:88:30: error: implicit declaration of function 'Calloc'; did you mean 'calloc'? [-Wimplicit-function-declaration]
   88 |   double *sample_count_mat = Calloc(n_bins * n_samples, double);
      |                              ^~~~~~
      |                              calloc
PeakSegJoint.c:88:57: error: expected expression before 'double'
   88 |   double *sample_count_mat = Calloc(n_bins * n_samples, double);
      |                                                         ^~~~~~
PeakSegJoint.c:105:7: error: implicit declaration of function 'Free'; did you mean 'free'? [-Wimplicit-function-declaration]
  105 |       Free(sample_count_mat);
      |       ^~~~
      |       free
PeakSegJoint.c:145:58: error: expected expression before 'double'
  145 |   double *sample_cumsum_mat = Calloc(n_bins * n_samples, double);
      |                                                          ^~~~~~
PeakSegJoint.c:146:55: error: expected expression before 'struct'
  146 |   struct LossIndex *diff_index_vec = Calloc(n_samples,struct LossIndex);
      |                                                       ^~~~~~
PeakSegJoint.c:176:44: error: expected expression before 'double'
  176 |   double *peak_loss_vec = Calloc(n_samples,double);
      |                                            ^~~~~~
PeakSegJoint.c:177:44: error: expected expression before 'double'
  177 |   double *seg1_loss_vec = Calloc(n_samples,double);
      |                                            ^~~~~~
PeakSegJoint.c: In function 'PeakSegJointHeuristicStep2':
PeakSegJoint.c:307:41: error: expected expression before 'double'
  307 |   double *left_bin_vec = Calloc(n_bins, double);
      |                                         ^~~~~~
PeakSegJoint.c:308:42: error: expected expression before 'double'
  308 |   double *right_bin_vec = Calloc(n_bins, double);
      |                                          ^~~~~~
PeakSegJoint.c:309:56: error: expected expression before 'double'
  309 |   double *left_cumsum_mat = Calloc(n_bins * n_samples, double);
      |                                                        ^~~~~~
PeakSegJoint.c:310:57: error: expected expression before 'double'
  310 |   double *right_cumsum_mat = Calloc(n_bins * n_samples, double);
      |                                                         ^~~~~~
PeakSegJoint.c:314:44: error: expected expression before 'double'
  314 |   double *seg1_loss_vec = Calloc(n_samples,double);
      |                                            ^~~~~~
PeakSegJoint.c: In function 'PeakSegJointHeuristicStep3':
PeakSegJoint.c:553:55: error: expected expression before 'struct'
  553 |   struct LossIndex *diff_index_vec = Calloc(n_samples,struct LossIndex);
      |                                                       ^~~~~~
make[1]: *** [/data/gannet/ripley/R/R-devel/etc/Makeconf:195: PeakSegJoint.o] Error 1
make[1]: Leaving directory '/data/gannet/ripley/R/packages/tests-Strict/PeakSegJoint/src'
ERROR: compilation failed for package ‘PeakSegJoint’
* removing ‘/data/gannet/ripley/R/packages/tests-strict/Libs/PeakSegJoint-lib/PeakSegJoint’
Command exited with non-zero status 1
Time 0:01.25, 0.61 + 0.20
```
from https://www.stats.ox.ac.uk/pub/bdr/Strict/PeakSegJoint.out